### PR TITLE
Make clickables look clickable

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7185,9 +7185,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/src/assets/scss/sealog.scss
+++ b/src/assets/scss/sealog.scss
@@ -156,6 +156,11 @@ button.btn-template {
 .event-image-data-card {
   border-color: $secondary;
   font-size: .8rem;
+  cursor: pointer;
+}
+
+.event-image-data-card:hover {
+  opacity: 0.7;
 }
 
 .event-input {

--- a/src/assets/scss/sealog.scss
+++ b/src/assets/scss/sealog.scss
@@ -322,3 +322,11 @@ td.rdtYear:hover {
   background: $body-bg;
   color: $info;
 }
+
+.clickable {
+  cursor: pointer;
+}
+
+.clickable:hover {
+  text-decoration: underline;
+}

--- a/src/assets/scss/sealog.scss
+++ b/src/assets/scss/sealog.scss
@@ -171,10 +171,19 @@ button.btn-template {
   color: $gray-300
 }
 
+.event-list-item:hover {
+  background-color: inherit;
+}
+
 .event-list-item.active {
   background-color: inherit;
   color: var(--bs-primary);
   border: none;
+}
+
+.event-list-item-summary {
+  width: 100%;
+  cursor: pointer;
 }
 
 tbody {

--- a/src/components/copy_cruise_to_clipboard.js
+++ b/src/components/copy_cruise_to_clipboard.js
@@ -82,6 +82,7 @@ class CopyCruiseToClipboard extends Component {
             className={'text-primary' + (this.props.className ? ' ' + this.props.className : '')}
             icon='clipboard'
             fixedWidth
+            role='button'
           />
         </CopyToClipboard>
       </OverlayTrigger>

--- a/src/components/cruise_form.js
+++ b/src/components/cruise_form.js
@@ -105,7 +105,13 @@ class CruiseForm extends Component {
             <a className='text-decoration-none' href='#' onClick={() => handle_cruise_file_download(file, this.props.cruise.id)}>
               {file}
             </a>{' '}
-            <FontAwesomeIcon onClick={() => this.handleFileDeleteModal(file)} className='text-danger' icon='trash' fixedWidth role='button' />
+            <FontAwesomeIcon
+              onClick={() => this.handleFileDeleteModal(file)}
+              className='text-danger'
+              icon='trash'
+              fixedWidth
+              role='button'
+            />
           </div>
         )
       })

--- a/src/components/cruise_form.js
+++ b/src/components/cruise_form.js
@@ -105,7 +105,7 @@ class CruiseForm extends Component {
             <a className='text-decoration-none' href='#' onClick={() => handle_cruise_file_download(file, this.props.cruise.id)}>
               {file}
             </a>{' '}
-            <FontAwesomeIcon onClick={() => this.handleFileDeleteModal(file)} className='text-danger' icon='trash' fixedWidth />
+            <FontAwesomeIcon onClick={() => this.handleFileDeleteModal(file)} className='text-danger' icon='trash' fixedWidth role='button' />
           </div>
         )
       })

--- a/src/components/cruise_menu.js
+++ b/src/components/cruise_menu.js
@@ -246,7 +246,9 @@ class CruiseMenu extends Component {
                 <Col
                   key={`select_${lowering.id}`}
                   className={
-                    (this.state.activeLowering && lowering.id === this.state.activeLowering.id ? 'text-warning ms-2' : 'text-primary ms-2') + ' clickable'
+                    (this.state.activeLowering && lowering.id === this.state.activeLowering.id
+                      ? 'text-warning ms-2'
+                      : 'text-primary ms-2') + ' clickable'
                   }
                   onClick={() => this.handleLoweringSelect(lowering.id)}
                 >
@@ -441,13 +443,18 @@ class CruiseMenu extends Component {
     if (this.state.yearCruises) {
       Object.entries(this.state.yearCruises).forEach(([year, cruises]) => {
         let yearTxt = (
-          <span className={(year == this.state.activeYear || this.state.years.size == 1 ? 'text-warning' : 'text-primary') + ' clickable'}>{year}</span>
+          <span className={(year == this.state.activeYear || this.state.years.size == 1 ? 'text-warning' : 'text-primary') + ' clickable'}>
+            {year}
+          </span>
         )
         let yearCruises = cruises.map((cruise) => {
           return (
             <div
               key={`select_${cruise.id}`}
-              className={(this.state.activeCruise && cruise.id === this.state.activeCruise.id ? 'ms-2 text-warning' : 'ms-2 text-primary') + ' clickable'}
+              className={
+                (this.state.activeCruise && cruise.id === this.state.activeCruise.id ? 'ms-2 text-warning' : 'ms-2 text-primary') +
+                ' clickable'
+              }
               onClick={() => this.handleCruiseSelect(cruise.id)}
             >
               {cruise.cruise_id}

--- a/src/components/cruise_menu.js
+++ b/src/components/cruise_menu.js
@@ -246,7 +246,7 @@ class CruiseMenu extends Component {
                 <Col
                   key={`select_${lowering.id}`}
                   className={
-                    this.state.activeLowering && lowering.id === this.state.activeLowering.id ? 'text-warning ms-2' : 'text-primary ms-2'
+                    (this.state.activeLowering && lowering.id === this.state.activeLowering.id ? 'text-warning ms-2' : 'text-primary ms-2') + ' clickable'
                   }
                   onClick={() => this.handleLoweringSelect(lowering.id)}
                 >
@@ -441,13 +441,13 @@ class CruiseMenu extends Component {
     if (this.state.yearCruises) {
       Object.entries(this.state.yearCruises).forEach(([year, cruises]) => {
         let yearTxt = (
-          <span className={year == this.state.activeYear || this.state.years.size == 1 ? 'text-warning' : 'text-primary'}>{year}</span>
+          <span className={(year == this.state.activeYear || this.state.years.size == 1 ? 'text-warning' : 'text-primary') + ' clickable'}>{year}</span>
         )
         let yearCruises = cruises.map((cruise) => {
           return (
             <div
               key={`select_${cruise.id}`}
-              className={this.state.activeCruise && cruise.id === this.state.activeCruise.id ? 'ms-2 text-warning' : 'ms-2 text-primary'}
+              className={(this.state.activeCruise && cruise.id === this.state.activeCruise.id ? 'ms-2 text-warning' : 'ms-2 text-primary') + ' clickable'}
               onClick={() => this.handleCruiseSelect(cruise.id)}
             >
               {cruise.cruise_id}
@@ -532,7 +532,7 @@ class CruiseMenu extends Component {
             if (this.state.activeLowering && lowering.id === this.state.activeLowering.id) {
               return (
                 <li key={`select_${lowering.id}`}>
-                  <span className='text-warning'>{lowering.lowering_id}</span>
+                  <span className='text-warning clickable'>{lowering.lowering_id}</span>
                   <br />
                 </li>
               )
@@ -540,7 +540,7 @@ class CruiseMenu extends Component {
 
             return (
               <li key={`select_${lowering.id}`} onClick={() => this.handleLoweringSelect(lowering.id)}>
-                <span className='text-primary'>{lowering.lowering_id}</span>
+                <span className='text-primary clickable'>{lowering.lowering_id}</span>
               </li>
             )
           })}

--- a/src/components/cruises.js
+++ b/src/components/cruises.js
@@ -261,7 +261,13 @@ class Cruises extends Component {
       if (index >= (this.state.activePage - 1) * maxCruisesPerPage && index < this.state.activePage * maxCruisesPerPage) {
         let editLink = (
           <OverlayTrigger placement='top' overlay={editTooltip}>
-            <FontAwesomeIcon className='text-warning' onClick={() => this.handleCruiseUpdate(cruise.id)} icon='pencil-alt' fixedWidth />
+            <FontAwesomeIcon
+              className='text-warning'
+              onClick={() => this.handleCruiseUpdate(cruise.id)}
+              icon='pencil-alt'
+              fixedWidth
+              role='button'
+            />
           </OverlayTrigger>
         )
 
@@ -273,19 +279,32 @@ class Cruises extends Component {
                 onClick={() => this.handleCruisePermissionsModal(cruise)}
                 icon='user-lock'
                 fixedWidth
+                role='button'
               />
             </OverlayTrigger>
           ) : null
 
         let deleteLink = this.props.roles.includes('admin') ? (
           <OverlayTrigger placement='top' overlay={deleteTooltip}>
-            <FontAwesomeIcon className='text-danger ps-1' onClick={() => this.handleCruiseDeleteModal(cruise.id)} icon='trash' fixedWidth />
+            <FontAwesomeIcon
+              className='text-danger ps-1'
+              onClick={() => this.handleCruiseDeleteModal(cruise.id)}
+              icon='trash'
+              fixedWidth
+              role='button'
+            />
           </OverlayTrigger>
         ) : null
 
         let exportLink = this.props.roles.includes('admin') ? (
           <OverlayTrigger placement='top' overlay={exportTooltip}>
-            <FontAwesomeIcon className='text-info ps-1' onClick={() => this.handleCruiseExportModal(cruise)} icon='download' fixedWidth />
+            <FontAwesomeIcon
+              className='text-info ps-1'
+              onClick={() => this.handleCruiseExportModal(cruise)}
+              icon='download'
+              fixedWidth
+              role='button'
+            />
           </OverlayTrigger>
         ) : null
 
@@ -296,6 +315,7 @@ class Cruises extends Component {
               onClick={() => (cruise.cruise_hidden ? this.handleCruiseShow(cruise.id) : this.handleCruiseHide(cruise.id))}
               icon={cruise.cruise_hidden ? 'eye-slash' : 'eye'}
               fixedWidth
+              role='button'
             />
           </OverlayTrigger>
         ) : null
@@ -374,7 +394,13 @@ class Cruises extends Component {
       <div>
         {_Cruises_}
         <OverlayTrigger placement='top' overlay={exportTooltip}>
-          <FontAwesomeIcon className='float-end pt-2 text-primary' onClick={() => this.exportCruisesToJSON()} icon='download' fixedWidth />
+          <FontAwesomeIcon
+            className='float-end pt-2 text-primary'
+            onClick={() => this.exportCruisesToJSON()}
+            icon='download'
+            fixedWidth
+            role='button'
+          />
         </OverlayTrigger>
         <Form className='float-end me-2'>
           {this.props.roles.includes('admin') ? (

--- a/src/components/event_history.js
+++ b/src/components/event_history.js
@@ -443,7 +443,7 @@ class EventHistory extends Component {
                 />
               ) : null}
             </Form>
-            <div className='float-end mt-1 pe-2 text-primary' style={{ fontSize: '.85rem' }} onClick={this.toggleASNAP}>
+            <div className='float-end mt-1 pe-2 text-primary clickable' style={{ fontSize: '.85rem' }} onClick={this.toggleASNAP}>
               {this.state.hideASNAP ? 'Show ASNAP' : 'Hide ASNAP'}
             </div>
           </React.Fragment>

--- a/src/components/event_history.js
+++ b/src/components/event_history.js
@@ -315,14 +315,14 @@ class EventHistory extends Component {
 
         eventArray.push(
           <ListGroup.Item key={event.id} className='event-list-item d-flex justify-content-between'>
-            <div onClick={() => this.handleEventShowDetailsModal(event)} className="event-list-item-summary">
+            <div onClick={() => this.handleEventShowDetailsModal(event)} className='event-list-item-summary'>
               {event.ts}{' '}
               <b>
                 <i>{event.event_author}</i>
               </b>
               : {event.event_value} {eventOptions ? <FontAwesomeIcon icon='arrow-right' fixedWidth /> : null} {eventOptions}
             </div>
-            <div role="button">{commentTooltip}</div>
+            <div role='button'>{commentTooltip}</div>
           </ListGroup.Item>
         )
       }

--- a/src/components/event_history.js
+++ b/src/components/event_history.js
@@ -315,7 +315,7 @@ class EventHistory extends Component {
 
         eventArray.push(
           <ListGroup.Item key={event.id} className='event-list-item d-flex justify-content-between'>
-            <div onClick={() => this.handleEventShowDetailsModal(event)}>
+            <div onClick={() => this.handleEventShowDetailsModal(event)} className="event-list-item-summary">
               {event.ts}{' '}
               <b>
                 <i>{event.event_author}</i>

--- a/src/components/event_history.js
+++ b/src/components/event_history.js
@@ -296,7 +296,7 @@ class EventHistory extends Component {
         }
         let eventOptions = eventOptionsArray.length > 0 ? eventOptionsArray.join(', ') : ''
         let commentIcon = comment_exists ? (
-          <FontAwesomeIcon onClick={() => this.handleEventCommentModal(event)} icon='comment' fixedWidth transform='grow-4' />
+          <FontAwesomeIcon onClick={() => this.handleEventCommentModal(event)} icon='comment' fixedWidth transform='grow-4' role='button' />
         ) : (
           <span onClick={() => this.handleEventCommentModal(event)} className='fa-layers fa-fw'>
             <FontAwesomeIcon icon='comment' fixedWidth transform='grow-4' />
@@ -322,7 +322,7 @@ class EventHistory extends Component {
               </b>
               : {event.event_value} {eventOptions ? <FontAwesomeIcon icon='arrow-right' fixedWidth /> : null} {eventOptions}
             </div>
-            <div>{commentTooltip}</div>
+            <div role="button">{commentTooltip}</div>
           </ListGroup.Item>
         )
       }
@@ -374,7 +374,7 @@ class EventHistory extends Component {
           <span className='float-end'>
             <i>{this.state.event.event_author}</i> @ {this.state.event.ts}
             <OverlayTrigger placement='top' overlay={showNewEventTooltip}>
-              <span className='float-end ps-2' size='sm' onClick={this.toggleNewEventDetails}>
+              <span className='float-end ps-2' size='sm' onClick={this.toggleNewEventDetails} role='button'>
                 <FontAwesomeIcon icon={showNewEventIcon} fixedWidth />
               </span>
             </OverlayTrigger>
@@ -416,6 +416,7 @@ class EventHistory extends Component {
             className='float-end'
             style={{ paddingTop: '8px' }}
             onClick={this.toggleEventHistory}
+            role='button'
           />
         </OverlayTrigger>
         {this.state.showEventHistory ? (
@@ -427,6 +428,7 @@ class EventHistory extends Component {
                 className='mx-2 float-end'
                 style={{ paddingTop: '8px' }}
                 onClick={this.toggleExpandedEventHistory}
+                role='button'
               />
             </OverlayTrigger>
             <Form className='float-end'>

--- a/src/components/event_management.js
+++ b/src/components/event_management.js
@@ -272,9 +272,9 @@ class EventManagement extends Component {
         }
         let eventOptions = eventOptionsArray.length > 0 ? eventOptionsArray.join(', ') : ''
         let commentIcon = comment_exists ? (
-          <FontAwesomeIcon onClick={() => this.handleEventCommentModal(event)} icon='comment' fixedWidth transform='grow-4' />
+          <FontAwesomeIcon onClick={() => this.handleEventCommentModal(event)} icon='comment' fixedWidth transform='grow-4' role='button' />
         ) : (
-          <span onClick={() => this.handleEventCommentModal(event)} className='fa-layers fa-fw'>
+          <span onClick={() => this.handleEventCommentModal(event)} className='fa-layers fa-fw' role='button'>
             <FontAwesomeIcon icon='comment' fixedWidth transform='grow-4' />
             <FontAwesomeIcon inverse icon='plus' style={{ color: 'var(--bs-black' }} fixedWidth transform='shrink-4' />
           </span>
@@ -290,7 +290,7 @@ class EventManagement extends Component {
         )
 
         let deleteIcon = (
-          <FontAwesomeIcon className={'text-danger me-1'} onClick={() => this.handleEventDeleteModal(event)} icon='trash' fixedWidth />
+          <FontAwesomeIcon className={'text-danger me-1'} onClick={() => this.handleEventDeleteModal(event)} icon='trash' fixedWidth role='button' />
         )
         let deleteTooltip =
           this.props.roles && this.props.roles.some((role) => ['admin', 'event_manager'].includes(role)) ? (

--- a/src/components/event_management.js
+++ b/src/components/event_management.js
@@ -290,7 +290,13 @@ class EventManagement extends Component {
         )
 
         let deleteIcon = (
-          <FontAwesomeIcon className={'text-danger me-1'} onClick={() => this.handleEventDeleteModal(event)} icon='trash' fixedWidth role='button' />
+          <FontAwesomeIcon
+            className={'text-danger me-1'}
+            onClick={() => this.handleEventDeleteModal(event)}
+            icon='trash'
+            fixedWidth
+            role='button'
+          />
         )
         let deleteTooltip =
           this.props.roles && this.props.roles.some((role) => ['admin', 'event_manager'].includes(role)) ? (
@@ -301,7 +307,7 @@ class EventManagement extends Component {
 
         return (
           <ListGroup.Item key={event.id} className='event-list-item d-flex justify-content-between'>
-            <div onClick={() => this.handleEventShowDetailsModal(event)} className="event-list-item-summary">
+            <div onClick={() => this.handleEventShowDetailsModal(event)} className='event-list-item-summary'>
               {event.ts}{' '}
               <b>
                 <i>{event.event_author}</i>

--- a/src/components/event_management.js
+++ b/src/components/event_management.js
@@ -301,7 +301,7 @@ class EventManagement extends Component {
 
         return (
           <ListGroup.Item key={event.id} className='event-list-item d-flex justify-content-between'>
-            <div onClick={() => this.handleEventShowDetailsModal(event)}>
+            <div onClick={() => this.handleEventShowDetailsModal(event)} className="event-list-item-summary">
               {event.ts}{' '}
               <b>
                 <i>{event.event_author}</i>

--- a/src/components/event_management.js
+++ b/src/components/event_management.js
@@ -239,7 +239,7 @@ class EventManagement extends Component {
       <div>
         {Label}
         <span className='float-end'>
-          <span className='me-2 text-primary' style={{ fontSize: '.85rem' }} onClick={this.toggleASNAP}>
+          <span className='me-2 text-primary clickable' style={{ fontSize: '.85rem' }} onClick={this.toggleASNAP}>
             {this.state.hideASNAP ? 'Show ASNAP' : 'Hide ASNAP'}
           </span>
           <ExportDropdown

--- a/src/components/event_templates.js
+++ b/src/components/event_templates.js
@@ -238,17 +238,30 @@ class EventTemplates extends Component {
             onClick={() => this.handleEventTemplateSelect(template.id)}
             icon='pencil-alt'
             fixedWidth
+            role='button'
           />
         </OverlayTrigger>
       ) : null
       const test_icon = (
         <OverlayTrigger placement='top' overlay={testTooltip}>
-          <FontAwesomeIcon className='text-success' onClick={() => this.handleEventTemplateTest(template)} icon='vial' fixedWidth />
+          <FontAwesomeIcon
+            className='text-success'
+            onClick={() => this.handleEventTemplateTest(template)}
+            icon='vial'
+            fixedWidth
+            role='button'
+          />
         </OverlayTrigger>
       )
       const delete_icon = this.props.roles.some((item) => edit_roles.includes(item)) ? (
         <OverlayTrigger placement='top' overlay={deleteTooltip}>
-          <FontAwesomeIcon className='text-danger' onClick={() => this.handleEventTemplateDelete(template.id)} icon='trash' fixedWidth />
+          <FontAwesomeIcon
+            className='text-danger'
+            onClick={() => this.handleEventTemplateDelete(template.id)}
+            icon='trash'
+            fixedWidth
+            role='button'
+          />
         </OverlayTrigger>
       ) : null
 
@@ -304,6 +317,7 @@ class EventTemplates extends Component {
             disabled={disableBtn}
             icon='download'
             fixedWidth
+            role='button'
           />
         </OverlayTrigger>
         {!system ? (
@@ -314,6 +328,7 @@ class EventTemplates extends Component {
               disabled={disableBtn}
               icon='trash'
               fixedWidth
+              role='button'
             />
           </OverlayTrigger>
         ) : null}

--- a/src/components/header.js
+++ b/src/components/header.js
@@ -149,7 +149,7 @@ class Header extends Component {
   render() {
     return (
       <Navbar collapseOnSelect expand='md' variant='dark'>
-        <Navbar.Brand className='ms-4' onClick={this.props.gotoHome}>
+        <Navbar.Brand className='ms-4 clickable' onClick={this.props.gotoHome}>
           {HEADER_TITLE}
         </Navbar.Brand>
         <Navbar.Toggle aria-controls='responsive-navbar-nav' />

--- a/src/components/lowerings.js
+++ b/src/components/lowerings.js
@@ -247,7 +247,13 @@ class Lowerings extends Component {
       if (index >= (this.state.activePage - 1) * maxLoweringsPerPage && index < this.state.activePage * maxLoweringsPerPage) {
         let editLink = (
           <OverlayTrigger placement='top' overlay={editTooltip}>
-            <FontAwesomeIcon className='text-warning' onClick={() => this.handleLoweringUpdate(lowering.id)} icon='pencil-alt' fixedWidth />
+            <FontAwesomeIcon
+              className='text-warning'
+              onClick={() => this.handleLoweringUpdate(lowering.id)}
+              icon='pencil-alt'
+              fixedWidth
+              role='button'
+            />
           </OverlayTrigger>
         )
 
@@ -259,19 +265,32 @@ class Lowerings extends Component {
                 onClick={() => this.handleLoweringPermissionsModal(lowering)}
                 icon='user-lock'
                 fixedWidth
+                role='button'
               />
             </OverlayTrigger>
           ) : null
 
         let deleteLink = this.props.roles.includes('admin') ? (
           <OverlayTrigger placement='top' overlay={deleteTooltip}>
-            <FontAwesomeIcon className='text-danger' onClick={() => this.handleLoweringDeleteModal(lowering.id)} icon='trash' fixedWidth />
+            <FontAwesomeIcon
+              className='text-danger'
+              onClick={() => this.handleLoweringDeleteModal(lowering.id)}
+              icon='trash'
+              fixedWidth
+              role='button'
+            />
           </OverlayTrigger>
         ) : null
 
         let exportLink = this.props.roles.includes('admin') ? (
           <OverlayTrigger placement='top' overlay={exportTooltip}>
-            <FontAwesomeIcon className='text-info' onClick={() => this.handleLoweringExportModal(lowering)} icon='download' fixedWidth />
+            <FontAwesomeIcon
+              className='text-info'
+              onClick={() => this.handleLoweringExportModal(lowering)}
+              icon='download'
+              fixedWidth
+              role='button'
+            />
           </OverlayTrigger>
         ) : null
 
@@ -282,6 +301,7 @@ class Lowerings extends Component {
               onClick={() => (lowering.lowering_hidden ? this.handleLoweringShow(lowering.id) : this.handleLoweringHide(lowering.id))}
               icon={lowering.lowering_hidden ? 'eye-slash' : 'eye'}
               fixedWidth
+              role='button'
             />
           </OverlayTrigger>
         ) : null
@@ -350,6 +370,7 @@ class Lowerings extends Component {
             onClick={() => this.exportLoweringsToJSON()}
             icon='download'
             fixedWidth
+            role='button'
           />
         </OverlayTrigger>
         <Form className='float-end me-2'>

--- a/src/components/review_gallery.js
+++ b/src/components/review_gallery.js
@@ -155,7 +155,7 @@ class ReviewGallery extends Component {
                 {imgCountOptions}
               </Form.Select>
             </Form.Group>
-            <span className='me-2 text-primary float-end' style={{ fontSize: '.85rem' }} onClick={this.toggleASNAP}>
+            <span className='me-2 text-primary float-end clickable' style={{ fontSize: '.85rem' }} onClick={this.toggleASNAP}>
               {this.props.event.hideASNAP ? 'Show ASNAP' : 'Hide ASNAP'}
             </span>
           </span>

--- a/src/components/review_map.js
+++ b/src/components/review_map.js
@@ -267,7 +267,13 @@ class ReviewMap extends Component {
           let eventOptions = eventOptionsArray.length > 0 ? eventOptionsArray.join(', ') : ''
           let eventComment = comment_exists ? (
             <OverlayTrigger placement='left' overlay={<Tooltip id={`commentTooltip_${event.id}`}>Edit/View Comment</Tooltip>}>
-              <FontAwesomeIcon onClick={() => this.handleEventCommentModal(index)} icon='comment' fixedWidth transform='grow-4' role='button' />
+              <FontAwesomeIcon
+                onClick={() => this.handleEventCommentModal(index)}
+                icon='comment'
+                fixedWidth
+                transform='grow-4'
+                role='button'
+              />
             </OverlayTrigger>
           ) : (
             <OverlayTrigger placement='top' overlay={<Tooltip id={`commentTooltip_${event.id}`}>Add Comment</Tooltip>}>
@@ -285,13 +291,19 @@ class ReviewMap extends Component {
 
           let eventDetails = (
             <OverlayTrigger placement='left' overlay={<Tooltip id={`commentTooltip_${event.id}`}>View Details</Tooltip>}>
-              <FontAwesomeIcon onClick={() => this.handleEventShowDetailsModal(index)} icon='window-maximize' fixedWidth className='me-1' role='button' />
+              <FontAwesomeIcon
+                onClick={() => this.handleEventShowDetailsModal(index)}
+                icon='window-maximize'
+                fixedWidth
+                className='me-1'
+                role='button'
+              />
             </OverlayTrigger>
           )
 
           return (
             <ListGroup.Item key={event.id} className='event-list-item d-flex justify-content-between' active={active}>
-              <div onClick={() => this.handleEventClick(index)} className="event-list-item-summary">
+              <div onClick={() => this.handleEventClick(index)} className='event-list-item-summary'>
                 {event.ts}{' '}
                 <b>
                   <i>{event.event_author}</i>

--- a/src/components/review_map.js
+++ b/src/components/review_map.js
@@ -216,7 +216,7 @@ class ReviewMap extends Component {
       <div>
         Filtered Events
         <span className='float-end'>
-          <span className='me-2 text-primary' style={{ fontSize: '.85rem' }} onClick={this.toggleASNAP}>
+          <span className='me-2 text-primary clickable' style={{ fontSize: '.85rem' }} onClick={this.toggleASNAP}>
             {this.props.event.hideASNAP ? 'Show ASNAP' : 'Hide ASNAP'}
           </span>
           <ExportDropdown

--- a/src/components/review_map.js
+++ b/src/components/review_map.js
@@ -267,11 +267,11 @@ class ReviewMap extends Component {
           let eventOptions = eventOptionsArray.length > 0 ? eventOptionsArray.join(', ') : ''
           let eventComment = comment_exists ? (
             <OverlayTrigger placement='left' overlay={<Tooltip id={`commentTooltip_${event.id}`}>Edit/View Comment</Tooltip>}>
-              <FontAwesomeIcon onClick={() => this.handleEventCommentModal(index)} icon='comment' fixedWidth transform='grow-4' />
+              <FontAwesomeIcon onClick={() => this.handleEventCommentModal(index)} icon='comment' fixedWidth transform='grow-4' role='button' />
             </OverlayTrigger>
           ) : (
             <OverlayTrigger placement='top' overlay={<Tooltip id={`commentTooltip_${event.id}`}>Add Comment</Tooltip>}>
-              <span onClick={() => this.handleEventCommentModal(index)} className='fa-layers fa-fw'>
+              <span onClick={() => this.handleEventCommentModal(index)} className='fa-layers fa-fw' role='button'>
                 <FontAwesomeIcon icon='comment' fixedWidth transform='grow-4' />
                 <FontAwesomeIcon
                   style={active ? { color: 'var(--bs-gray-700' } : { color: 'var(--bs-gray-800' }}
@@ -285,7 +285,7 @@ class ReviewMap extends Component {
 
           let eventDetails = (
             <OverlayTrigger placement='left' overlay={<Tooltip id={`commentTooltip_${event.id}`}>View Details</Tooltip>}>
-              <FontAwesomeIcon onClick={() => this.handleEventShowDetailsModal(index)} icon='window-maximize' fixedWidth className='me-1' />
+              <FontAwesomeIcon onClick={() => this.handleEventShowDetailsModal(index)} icon='window-maximize' fixedWidth className='me-1' role='button' />
             </OverlayTrigger>
           )
 

--- a/src/components/review_map.js
+++ b/src/components/review_map.js
@@ -291,7 +291,7 @@ class ReviewMap extends Component {
 
           return (
             <ListGroup.Item key={event.id} className='event-list-item d-flex justify-content-between' active={active}>
-              <div onClick={() => this.handleEventClick(index)}>
+              <div onClick={() => this.handleEventClick(index)} className="event-list-item-summary">
                 {event.ts}{' '}
                 <b>
                   <i>{event.event_author}</i>

--- a/src/components/review_replay.js
+++ b/src/components/review_replay.js
@@ -297,6 +297,7 @@ class ReviewReplay extends Component {
             key={`pause_${this.props.cruise.id}`}
             onClick={() => this.handleReviewReplayPause()}
             icon='pause'
+            role='button'
           />
         ) : (
           <FontAwesomeIcon
@@ -304,6 +305,7 @@ class ReviewReplay extends Component {
             key={`play_${this.props.cruise.id}`}
             onClick={() => this.handleReviewReplayPlay()}
             icon='play'
+            role='button'
           />
         )
 
@@ -315,12 +317,14 @@ class ReviewReplay extends Component {
               key={`start_${this.props.cruise.id}`}
               onClick={() => this.handleReviewReplayStart()}
               icon='step-backward'
+              role='button'
             />{' '}
             <FontAwesomeIcon
               className='text-primary'
               key={`frev_${this.props.cruise.id}`}
               onClick={() => this.handleReviewReplayFRev()}
               icon='backward'
+              role='button'
             />{' '}
             {playPause}{' '}
             <FontAwesomeIcon
@@ -328,12 +332,14 @@ class ReviewReplay extends Component {
               key={`ffwd_${this.props.cruise.id}`}
               onClick={() => this.handleReviewReplayFFwd()}
               icon='forward'
+              role='button'
             />{' '}
             <FontAwesomeIcon
               className='text-primary'
               key={`end_${this.props.cruise.id}`}
               onClick={() => this.handleReviewReplayEnd()}
               icon='step-forward'
+              role='button'
             />
           </span>
         ) : (
@@ -413,11 +419,11 @@ class ReviewReplay extends Component {
 
           let eventComment = comment_exists ? (
             <OverlayTrigger placement='left' overlay={<Tooltip id={`commentTooltip_${event.id}`}>Edit/View Comment</Tooltip>}>
-              <FontAwesomeIcon onClick={() => this.handleEventCommentModal(index)} icon='comment' fixedWidth transform='grow-4' />
+              <FontAwesomeIcon onClick={() => this.handleEventCommentModal(index)} icon='comment' fixedWidth transform='grow-4' role='button' />
             </OverlayTrigger>
           ) : (
             <OverlayTrigger placement='top' overlay={<Tooltip id={`commentTooltip_${event.id}`}>Add Comment</Tooltip>}>
-              <span onClick={() => this.handleEventCommentModal(index)} className='fa-layers fa-fw'>
+              <span onClick={() => this.handleEventCommentModal(index)} className='fa-layers fa-fw' role='button'>
                 <FontAwesomeIcon icon='comment' fixedWidth transform='grow-4' />
                 <FontAwesomeIcon
                   style={active ? { color: 'var(--bs-gray-700' } : { color: 'var(--bs-gray-800' }}

--- a/src/components/review_replay.js
+++ b/src/components/review_replay.js
@@ -419,7 +419,13 @@ class ReviewReplay extends Component {
 
           let eventComment = comment_exists ? (
             <OverlayTrigger placement='left' overlay={<Tooltip id={`commentTooltip_${event.id}`}>Edit/View Comment</Tooltip>}>
-              <FontAwesomeIcon onClick={() => this.handleEventCommentModal(index)} icon='comment' fixedWidth transform='grow-4' role='button' />
+              <FontAwesomeIcon
+                onClick={() => this.handleEventCommentModal(index)}
+                icon='comment'
+                fixedWidth
+                transform='grow-4'
+                role='button'
+              />
             </OverlayTrigger>
           ) : (
             <OverlayTrigger placement='top' overlay={<Tooltip id={`commentTooltip_${event.id}`}>Add Comment</Tooltip>}>
@@ -437,7 +443,7 @@ class ReviewReplay extends Component {
 
           return (
             <ListGroup.Item key={event.id} className='event-list-item d-flex justify-content-between' active={active}>
-              <div onClick={() => this.handleEventClick(index)} className="event-list-item-summary">
+              <div onClick={() => this.handleEventClick(index)} className='event-list-item-summary'>
                 {event.ts}{' '}
                 <b>
                   <i>{event.event_author}</i>

--- a/src/components/review_replay.js
+++ b/src/components/review_replay.js
@@ -437,7 +437,7 @@ class ReviewReplay extends Component {
 
           return (
             <ListGroup.Item key={event.id} className='event-list-item d-flex justify-content-between' active={active}>
-              <div onClick={() => this.handleEventClick(index)}>
+              <div onClick={() => this.handleEventClick(index)} className="event-list-item-summary">
                 {event.ts}{' '}
                 <b>
                   <i>{event.event_author}</i>

--- a/src/components/review_replay.js
+++ b/src/components/review_replay.js
@@ -379,7 +379,7 @@ class ReviewReplay extends Component {
       <div>
         Filtered Events
         <span className='float-end'>
-          <span className='me-2 text-primary' style={{ fontSize: '.85rem' }} onClick={this.toggleASNAP}>
+          <span className='me-2 text-primary clickable' style={{ fontSize: '.85rem' }} onClick={this.toggleASNAP}>
             {this.props.event.hideASNAP ? 'Show ASNAP' : 'Hide ASNAP'}
           </span>
           <ExportDropdown

--- a/src/components/tasks.js
+++ b/src/components/tasks.js
@@ -121,6 +121,7 @@ class Tasks extends Component {
           onMouseEnter={() => this.setState({ description: importEventsDescription })}
           onMouseLeave={() => this.setState({ description: '' })}
           onClick={() => this.handleEventImport()}
+          className='clickable'
         >
           Import Event Records
         </ListGroup.Item>
@@ -128,6 +129,7 @@ class Tasks extends Component {
           onMouseEnter={() => this.setState({ description: importAuxDataDescription })}
           onMouseLeave={() => this.setState({ description: '' })}
           onClick={() => this.handleAuxDataImport()}
+          className='clickable'
         >
           Import Aux Data Records
         </ListGroup.Item>
@@ -135,6 +137,7 @@ class Tasks extends Component {
           onMouseEnter={() => this.setState({ description: dataResetDescription })}
           onMouseLeave={() => this.setState({ description: '' })}
           onClick={() => this.handleDataWipe()}
+          className='clickable'
         >
           Wipe Local Database
         </ListGroup.Item>

--- a/src/components/users.js
+++ b/src/components/users.js
@@ -221,20 +221,38 @@ class Users extends Component {
     return userList.map((user) => {
       const edit_icon = this.props.roles.some((item) => edit_roles.includes(item)) ? (
         <OverlayTrigger placement='top' overlay={editTooltip}>
-          <FontAwesomeIcon className='text-warning' onClick={() => this.handleUserSelect(user.id)} icon='pencil-alt' fixedWidth />
+          <FontAwesomeIcon
+            className='text-warning'
+            onClick={() => this.handleUserSelect(user.id)}
+            icon='pencil-alt'
+            fixedWidth
+            role='button'
+          />
         </OverlayTrigger>
       ) : null
 
       const jwt_icon = this.props.roles.includes('admin') ? (
         <OverlayTrigger placement='top' overlay={tokenTooltip}>
-          <FontAwesomeIcon className='text-success' onClick={() => this.handleDisplayUserToken(user.id)} icon='eye' fixedWidth />
+          <FontAwesomeIcon
+            className='text-success'
+            onClick={() => this.handleDisplayUserToken(user.id)}
+            icon='eye'
+            fixedWidth
+            role='button'
+          />
         </OverlayTrigger>
       ) : null
 
       const delete_icon =
         user.id !== this.props.profileid && !disabledAccounts.includes(user.username) ? (
           <OverlayTrigger placement='top' overlay={deleteTooltip}>
-            <FontAwesomeIcon className='text-danger' onClick={() => this.handleUserDelete(user.id)} icon='trash' fixedWidth />
+            <FontAwesomeIcon
+              className='text-danger'
+              onClick={() => this.handleUserDelete(user.id)}
+              icon='trash'
+              fixedWidth
+              role='button'
+            />
           </OverlayTrigger>
         ) : null
 
@@ -246,6 +264,7 @@ class Users extends Component {
               onClick={() => this.handleUserPermissionsModal(user.id)}
               icon='user-lock'
               fixedWidth
+              role='button'
             />
           </OverlayTrigger>
         ) : null
@@ -302,6 +321,7 @@ class Users extends Component {
             disabled={disableBtn}
             icon='download'
             fixedWidth
+            role='button'
           />
         </OverlayTrigger>
         {!system ? (
@@ -312,6 +332,7 @@ class Users extends Component {
               disabled={disableBtn}
               icon='trash'
               fixedWidth
+              role='button'
             />
           </OverlayTrigger>
         ) : null}

--- a/src/components/users.js
+++ b/src/components/users.js
@@ -246,13 +246,7 @@ class Users extends Component {
       const delete_icon =
         user.id !== this.props.profileid && !disabledAccounts.includes(user.username) ? (
           <OverlayTrigger placement='top' overlay={deleteTooltip}>
-            <FontAwesomeIcon
-              className='text-danger'
-              onClick={() => this.handleUserDelete(user.id)}
-              icon='trash'
-              fixedWidth
-              role='button'
-            />
+            <FontAwesomeIcon className='text-danger' onClick={() => this.handleUserDelete(user.id)} icon='trash' fixedWidth role='button' />
           </OverlayTrigger>
         ) : null
 


### PR DESCRIPTION
Minor styling changes to make elements that do something when you click on them look that way (e.g. mouse changes to hand, hover effects). With the way that npm compiles, you can't (or at least I couldn't figure out how to) just do an `[onClick]` css selector, so clickable icons got a `role='button'`, and everything else got a `clickable` class or custom styling.