### PR TITLE
Add per-template event button color option

### DIFF
--- a/src/client_settings.js.dist
+++ b/src/client_settings.js.dist
@@ -120,6 +120,10 @@ const AUX_DATA_DATASOURCE_REPLACE = null
 // i.e. ['science','problem','vehicle']
 const CATEGORY_SORT_ORDER = null
 
+// Default button color (Bootstrap variant name) used for event templates
+// that do not specify their own event_button_color.
+const DEFAULT_EVENT_TEMPLATE_BUTTON_COLOR = 'primary'
+
 module.exports = {
   API_ROOT_URL,
   WS_ROOT_URL,
@@ -145,5 +149,6 @@ module.exports = {
   IMAGES_AUX_DATA_SOURCES,
   AUX_DATA_SORT_ORDER,
   AUX_DATA_DATASOURCE_REPLACE,
-  CATEGORY_SORT_ORDER
+  CATEGORY_SORT_ORDER,
+  DEFAULT_EVENT_TEMPLATE_BUTTON_COLOR
 }

--- a/src/components/event_template_form.js
+++ b/src/components/event_template_form.js
@@ -7,7 +7,11 @@ import { Button, Card, Form, Row } from 'react-bootstrap'
 import PropTypes from 'prop-types'
 import { renderAlert, renderHidden, renderMessage, renderSelectField, renderSwitch, renderTextField, renderTextArea } from './form_elements'
 import * as mapDispatchToProps from '../actions'
-import { EventTemplateOptionTypes, EventTemplateVisibilityOptionTypes } from '../event_template_option_types'
+import {
+  EventTemplateOptionTypes,
+  EventTemplateVisibilityOptionTypes,
+  EventTemplateButtonColorOptions
+} from '../event_template_option_types'
 
 class EventTemplateForm extends Component {
   constructor(props) {
@@ -270,6 +274,16 @@ class EventTemplateForm extends Component {
               <Row>
                 <Field name='event_name' component={renderTextField} label='Button Name' required={true} sm={6} lg={6} />
                 <Field name='event_value' component={renderTextField} label='Event Value' required={true} sm={6} lg={6} />
+              </Row>
+              <Row>
+                <Field
+                  name='event_button_color'
+                  component={renderSelectField}
+                  options={EventTemplateButtonColorOptions}
+                  label='Button Color'
+                  sm={6}
+                  lg={6}
+                />
               </Row>
               <Row>
                 <Field

--- a/src/components/event_template_list.js
+++ b/src/components/event_template_list.js
@@ -6,7 +6,7 @@ import EventTemplateOptionsModal from './event_template_options_modal'
 import { Client } from '@hapi/nes/lib/client'
 import { connectWSClient } from '../utils'
 import cookies from '../cookies'
-import { WS_ROOT_URL, CATEGORY_SORT_ORDER } from '../client_settings'
+import { WS_ROOT_URL, CATEGORY_SORT_ORDER, DEFAULT_EVENT_TEMPLATE_BUTTON_COLOR } from '../client_settings'
 import * as mapDispatchToProps from '../actions'
 
 const sortCategories = (category_list) => {
@@ -162,7 +162,7 @@ class EventTemplateList extends Component {
                       return (
                         <Button
                           className='btn-template'
-                          variant='primary'
+                          variant={event_template.event_button_color || DEFAULT_EVENT_TEMPLATE_BUTTON_COLOR}
                           to='#'
                           key={`template_${event_template.id}`}
                           onClick={(e) => this.handleEventSubmit(event_template, e)}
@@ -181,7 +181,7 @@ class EventTemplateList extends Component {
                   return (
                     <Button
                       className='btn-template'
-                      variant='primary'
+                      variant={event_template.event_button_color || DEFAULT_EVENT_TEMPLATE_BUTTON_COLOR}
                       to='#'
                       key={`template_${event_template.id}`}
                       onClick={(e) => this.handleEventSubmit(event_template, e)}
@@ -200,7 +200,7 @@ class EventTemplateList extends Component {
             return (
               <Button
                 className='btn-template'
-                variant='primary'
+                variant={event_template.event_button_color || DEFAULT_EVENT_TEMPLATE_BUTTON_COLOR}
                 to='#'
                 key={`template_${event_template.id}`}
                 onClick={(e) => this.handleEventSubmit(event_template, e)}

--- a/src/event_template_option_types.js
+++ b/src/event_template_option_types.js
@@ -1,2 +1,3 @@
 export const EventTemplateOptionTypes = ['static text', 'text', 'dropdown', 'checkboxes', 'radio buttons']
 export const EventTemplateVisibilityOptionTypes = ['always', 'show if', 'hide if']
+export const EventTemplateButtonColorOptions = ['primary', 'secondary', 'success', 'danger', 'warning', 'info', 'dark']


### PR DESCRIPTION
## Summary
- Event templates can now set an `event_button_color` field to override the button's Bootstrap variant in the event logging UI
- Falls back to a new `DEFAULT_EVENT_TEMPLATE_BUTTON_COLOR` client setting (defaults to `primary`, preserving current behavior) when a template doesn't specify a color
- Adds a "Button Color" dropdown to the event template form (`EventTemplateButtonColorOptions`: primary, secondary, success, danger, warning, info, dark)

## Test plan
- [x] `npm run lint` passes
- [x] `npm run build` succeeds
- [x] Create/edit an event template, set a button color, confirm it renders with that variant in the event logging view
- [x] Confirm templates without a color still render with the default variant